### PR TITLE
DOC: fix errors with `html_static_path` and code.rst

### DIFF
--- a/docs/source/_static/.gitignore
+++ b/docs/source/_static/.gitignore
@@ -1,0 +1,1 @@
+# Empty folders cannot be commited to Git.

--- a/docs/source/code.rst
+++ b/docs/source/code.rst
@@ -1,13 +1,9 @@
 Code documentation
 ==================
 
-Core
------
-.. automodule:: ladisk_template_project.core
-    :members:
-
-
-Visualization
--------------
-.. automodule:: ladisk_template_project.visualize
-    :members:
+..
+    Some module
+    -----------
+    .. automodule:: sdypy.module_name
+        :members:
+..


### PR DESCRIPTION
The error with the directory `html_static_path` was fixed by creating a "_static" directory inside the docs/source dir (it probably existed before, but was not commited to Git as it was empty).

The "code.rst" source file contained a refernce to a non-existing Python module, which was removed to resolve the error.