### PR TITLE
SEP-005: change type, add discussion link

### DIFF
--- a/docs/seps/sep-0005.rst
+++ b/docs/seps/sep-0005.rst
@@ -4,7 +4,7 @@ SEP 5 — SDyPy Unified timeseries
 
 :Authors: Wout Weijtjens <wout.weijtjens@vub.be>, Janko Slavič <janko.slavic@fs.uni-lj.si>
 :Status: Draft
-:Type: Process
+:Type: Standards
 :Created: 2023-07-07
 
 
@@ -77,6 +77,9 @@ Discussion
 ----------
 
 This proposal is open for discussion and suggestions.
+
+The discussion is here:
+ - `Issue #15 <https://github.com/sdypy/sdypy/issues/15>`_
 
 Copyright
 ---------


### PR DESCRIPTION
I've changed the type of the [SEP-005 proposal](https://github.com/sdypy/sdypy/pull/17/files) to "Standards", to adhere to [SEP-000](https://github.com/sdypy/sdypy/blob/main/docs/seps/sep-0000.rst).

I've also added a link to the discussion issue at the bottom.